### PR TITLE
refactor: extract java version out to constant

### DIFF
--- a/buildSrc/src/main/kotlin/JavaVersion.kt
+++ b/buildSrc/src/main/kotlin/JavaVersion.kt
@@ -1,0 +1,3 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+
+val JAVA_VERSION = JavaLanguageVersion.of(21)

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -22,6 +22,6 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JAVA_VERSION)
     }
 }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -20,6 +20,6 @@ dependencies {
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs += "-Xjsr305=strict"
-        jvmTarget = "21"
+        jvmTarget = JAVA_VERSION.toString()
     }
 }


### PR DESCRIPTION
Extract the java version out so the JDK target is the same for kotlin and java